### PR TITLE
added missing import

### DIFF
--- a/jack/freedb.py
+++ b/jack/freedb.py
@@ -24,6 +24,7 @@ import os
 import locale
 import codecs
 import tempfile
+import traceback
 import shutil
 import re
 


### PR DESCRIPTION
solves `NameError: global name 'traceback' is not defined` due to offline freedb servers
