### PR TITLE
let the user continue ripping after rejecting all metadata matches

### DIFF
--- a/jack/config.py
+++ b/jack/config.py
@@ -606,7 +606,7 @@ replacement_chars = ["ae", "oe", "ue", "Ae", "Oe", "Ue", "ss", ""]""",
     'cont_failed_query': {
         'type': bool,
         'val': 0,
-        'usage': "continue without metadata data if query fails",
+        'usage': "continue without metadata if query fails",
         'long': 'AUTO',
     },
     'edit_cddb': {

--- a/jack/freedb.py
+++ b/jack/freedb.py
@@ -19,7 +19,6 @@
 # Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
 
 import string
-import sys
 import os
 import requests
 
@@ -180,8 +179,8 @@ def freedb_query(cd_ids, tracks, file):
                 except ValueError:
                     x = -1    # start the loop again
                 if not x:
-                    print("ok, aborting.")
-                    sys.exit()
+                    err = 2  # user rejected all matches
+                    return err
 
             buf = matches[x - 1]
             buf = buf.split(" ", 2)

--- a/jack/freedb.py
+++ b/jack/freedb.py
@@ -257,11 +257,8 @@ def freedb_names(cd_ids, tracks, todo, name, verb=0, warn=1):
         try:
             line = bline.decode("utf-8")
         except UnicodeDecodeError:
-            try:
-                line = bline.decode("latin1")
-            except UnicodeDecodeError:
-                print(bline)
-                error("could not decode above line")
+            # latin1 maps all 256 byte values, so this cannot fail
+            line = bline.decode("latin1")
         line = line.replace("\n", "")
         # cannot use rstrip, we need trailing spaces
         line = line.replace("\r", "")

--- a/jack/functions.py
+++ b/jack/functions.py
@@ -298,11 +298,8 @@ def real_cdrdao_gettoc(tocfile, silent=False):     # get toc from cdrdao-style t
         try:
             line = bline.decode("utf-8")
         except UnicodeDecodeError:
-            try:
-                line = bline.decode("latin1")
-            except UnicodeDecodeError:
-                print(bline)
-                error("could not decode above data")
+            # latin1 maps all 256 byte values, so this cannot fail
+            line = bline.decode("latin1")
         if not line:
             if current_track.channels not in [1, 2, 4]:
                 debug("track %02d: unknown number of channels, assuming 2" % num)

--- a/jack/musicbrainz.py
+++ b/jack/musicbrainz.py
@@ -189,9 +189,9 @@ def musicbrainz_query(cd_id, tracks, file):
                     except ValueError:
                         x = -1    # start the loop again
                     if not x:
-                        print("ok, aborting.")
                         print("A new release can be added using this URL:\n" + musicbrainz_getlookupurl(tracks, cd_id))
-                        sys.exit(1)
+                        err = 2  # user rejected all releases
+                        return err
                     if userinput.startswith("/"):
                         filter = userinput[1:]
                     else:

--- a/jack/prepare.py
+++ b/jack/prepare.py
@@ -389,11 +389,8 @@ def guess_decode(bytes_string):
     try:
         decoded_string = bytes_string.decode("utf-8")
     except UnicodeDecodeError:
-        try:
-            decoded_string = bytes_string.decode("latin1")
-        except UnicodeDecodeError:
-            print(bytes_string)
-            error("could not decode above data")
+        # latin1 maps all 256 byte values, so this cannot fail
+        decoded_string = bytes_string.decode("latin1")
     return decoded_string
 
 

--- a/jack/prepare.py
+++ b/jack/prepare.py
@@ -536,20 +536,26 @@ def metadata_lookup():
 def query_on_start(todo):
     info("querying...")
     metadata_form_file = jack.metadata.get_metadata_form_file(jack.metadata.get_metadata_api(cf['_metadata_server']))
-    if jack.metadata.metadata_query(jack.metadata.metadata_id(jack.ripstuff.all_tracks), jack.ripstuff.all_tracks, metadata_form_file):
-        if cf['_cont_failed_query']:
-
-            x = input("\nmetadata search failed, continue? (y/N) ") + "x"
-            if not x or x[0].upper() != "Y":
-                sys.exit(0)
-            if not cf['_edit_metadata']:
-                x = input("\nDo you want to edit the metadata file?  (y/N) ") + "x"
-                if x and x[0].upper() == "Y":
-                    cf['_edit_metadata'] = 1
-                else:
-                    cf['_query_on_start'] = 0
+    err = jack.metadata.metadata_query(jack.metadata.metadata_id(jack.ripstuff.all_tracks), jack.ripstuff.all_tracks, metadata_form_file)
+    if err:
+        # err == 2 means the user rejected all matches; someone is at the
+        # keyboard, so offer to continue even without --cont-failed-query.
+        if err == 2:
+            prompt = "\nno matching release chosen, continue ripping without metadata? (y/N) "
+        elif cf['_cont_failed_query']:
+            prompt = "\nmetadata search failed, continue ripping without metadata? (y/N) "
         else:
             jack.display.exit(1)
+
+        x = input(prompt) + "x"
+        if not x or x[0].upper() != "Y":
+            sys.exit(0)
+        if not cf['_edit_metadata']:
+            x = input("\nDo you want to edit the metadata file?  (y/N) ") + "x"
+            if x and x[0].upper() == "Y":
+                cf['_edit_metadata'] = 1
+            else:
+                cf['_query_on_start'] = 0
 
     if cf['_edit_metadata']:
         file = metadata_form_file
@@ -586,7 +592,8 @@ def query_on_start(todo):
         # don't tag the files.  However, if the metdata can be parsed
         # even though the query failed assume that the query worked and
         # do the tagging (the user might have edited the file by hand).
-        if cf['_cont_failed_query'] and err:
+        # This point is only reached after a failed or rejected query.
+        if err:
             cf['_set_tag'] = 0
         else:
             cf['_query_on_start'] = 1

--- a/jack/term.py
+++ b/jack/term.py
@@ -110,11 +110,10 @@ def xtermset_enable():
             want_y = want_y + 1
         want_y += 7  # for the help panel
         if (size_x, size_y) != (want_x, want_y):
-            try:
-                os.system("xtermset -geom %dx%d" % (want_x, want_y))
+            if os.system("xtermset -geom %dx%d" % (want_x, want_y)) == 0:
                 geom_changed = 1
                 resize()
-            except OSError:
+            else:
                 warning("failed to call xtermset, is it really installed?")
                 xtermset = 0
         del want_x, want_y
@@ -124,11 +123,8 @@ def xtermset_disable():
     import os
     global geom_changed
     if xtermset and geom_changed:
-        try:
-            os.system("xtermset -restore -geom %dx%d" % (orig_size_x, orig_size_y))
+        if os.system("xtermset -restore -geom %dx%d" % (orig_size_x, orig_size_y)) == 0:
             geom_changed = 0
-        except OSError:
-            pass
 
 
 def getsize():


### PR DESCRIPTION
Fixes #60.

Selecting "0.) none of the above" in the MusicBrainz or freedb match chooser used to call sys.exit() on the spot, so a disc that only had wrong matches in the database could not be ripped at all. Even --cont-failed-query could not help, because the chooser aborted before that option was ever consulted (which is what happened to @musger, whose rc file has cont_failed_query set).

With this change, rejecting all matches is reported to the caller as a failed query (a distinct error value, so it can be told apart from network failures and missing entries). During query-on-start, jack then asks:

```
no matching release chosen, continue ripping without metadata? (y/N)
```

This prompt appears regardless of --cont-failed-query: the user has just been interacting with the chooser, so there is no unattended run to protect. Genuine query failures keep the existing flag-gated behavior, so scripted runs without the flag still exit as before. Answering y drops into the existing continue-without-metadata flow: generic track names, no tagging. The "add a new release using this URL" hint is preserved.

For query-when-ready the rejection now exits through jack.display.exit() with the ripped files intact, instead of sys.exit(1).

Two small tidy-ups included: freedb.py no longer imports sys (unused after this change), and the --cont-failed-query help text loses a duplicated word.

Test plan before merging: with a disc that produces inexact matches, reject then continue (expect a rip with generic names and no tags), reject then decline (expect a clean exit), and the same rejection during query-when-ready after a finished rip.
